### PR TITLE
Correct formatting of depends field

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,5 +7,5 @@ paragraph=Simple webserver, supports GET/HEAD and POST.  Designed to reduce bloc
 category=Other
 url=https://github.com/MHotchin/YAAWS
 architectures=*
-depends=Ethernet SdFat
+depends=Ethernet, SdFat
 includes=YAAWS.h


### PR DESCRIPTION
The dependencies list must be comma separated.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format