### PR TITLE
Correct filename case in #include directive

### DIFF
--- a/src/YAAWS.h
+++ b/src/YAAWS.h
@@ -24,7 +24,7 @@
 #define _YAAWS_h
 
 #if defined(ARDUINO) && ARDUINO >= 100
-#include "arduino.h"
+#include "Arduino.h"
 #else
 #include "WProgram.h"
 #endif


### PR DESCRIPTION
Use of incorrect filename case of Arduino.h causes compilation to fail on filename case-sensitive operating systems like Linux.